### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=In the scenarios that a user wants to gather and show data from variou
 category=Sensors
 url=https://github.com/NordicAlliance/arduino-tgui
 architectures=*
+depends=Adafruit BME280 Library, Adafruit Unified Sensor, Adafruit GFX Library, Battery Sense, VL53L0X


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format